### PR TITLE
Craft and Name for Plasma Sword

### DIFF
--- a/src/main/resources/assets/mekaevolution/lang/en_us.json
+++ b/src/main/resources/assets/mekaevolution/lang/en_us.json
@@ -34,5 +34,6 @@
   "item.mekaevolution.cosmic_control_circuit": "Cosmic Control Circuit",
   "item.mekaevolution.infinite_control_circuit": "Infinite Control Circuit",
 
-  "item.mekaevolution.plasma_pickaxe": "Plasma Pickaxe"
+  "item.mekaevolution.plasma_pickaxe": "Plasma Pickaxe",
+  "item.mekaevolution.plasma_sword": "Plasma Sword"
 }

--- a/src/main/resources/data/mekaevolution/recipes/plasma_sword.json
+++ b/src/main/resources/data/mekaevolution/recipes/plasma_sword.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "key": {
+    "A": {
+      "item": "mekanism:enriched_diamond"
+    },
+    "P": {
+      "item": "mekanism:energy_tablet"
+    },
+    "D": {
+      "item": "mekanism:hdpe_stick"
+    }
+  },
+  "pattern": ["AA ", "AP ", " D "],
+  "result": {
+    "count": 1,
+    "item": "mekaevolution:plasma_sword"
+  }
+}


### PR DESCRIPTION
Added craft for plasma sword

pattern: 
              "AA ",
              "AP ",
              " D "

Where:

- "A": "mekanism:enriched_diamond"
- "P": "mekanism:energy_tablet"
- "D": "mekanism:hdpe_stick"
   